### PR TITLE
Changes main path in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ra-data-springboot-rest",
   "version": "1.0.0",
   "description": "React Admin Data Provider for SpringBoot REST",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "module": "esm/index.js",
   "files": ["*.md", "lib", "esm", "src"],
   "scripts": {


### PR DESCRIPTION
### Problem:
When fetching the package using `npm install` in a create-react-app, user will get a compilation error that `ra-data-springboot-data` can not be resolved.

The problem is because the main entry defined in packages.json is pointing to a non-existing path `lib/index.js`.

### Solution:
Either create the wrong path and copy `index.js` under the created path `lib`, or just change the main entry to `src/index.js`, I did the latter.

### Reference:
https://github.com/vishpat/ra-data-springboot-rest/issues/4

@vishpat I'll mention you since I can't add you as a reviewer.